### PR TITLE
patch 8.2.0236: MS-Windows unintall doesn't delete vimtutur.bat

### DIFF
--- a/src/uninstall.c
+++ b/src/uninstall.c
@@ -233,6 +233,10 @@ remove_batfiles(int doit)
     int	 i;
     int	 found = 0;
 
+    // avoid looking in the "installdir" by chdir to system root
+    mch_chdir(sysdrive);
+    mch_chdir("\\");
+
     for (i = 1; i < TARGET_COUNT; ++i)
     {
 	batfile_path = searchpath_save(targets[i].batname);
@@ -249,6 +253,8 @@ remove_batfiles(int doit)
 	    free(batfile_path);
 	}
     }
+
+    mch_chdir(installdir);
     return found;
 }
 

--- a/src/version.c
+++ b/src/version.c
@@ -743,6 +743,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    236,
+/**/
     235,
 /**/
     234,


### PR DESCRIPTION
Problem:    MS-Windows unintall doesn't delete vimtutur.bat.
Solution:   Change directory before deletion. (Ken Takata, closes #5603)